### PR TITLE
Class Label Override: "Add slot to override the label #165"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,25 @@
+{
+  "name": "sveltejs-forms",
+  "version": "0.0.0-semantically-released",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@smui/common": {
+      "version": "1.0.0-beta.21",
+      "resolved": "https://registry.npmjs.org/@smui/common/-/common-1.0.0-beta.21.tgz",
+      "integrity": "sha512-t063AKMVeKLl91C7HyMqWerrEMal1rIAHis6kH/HRWuqudLfQ2vrGCKq3SMLEL6t4OqgiXg122g0FDBk5t4M1A==",
+      "dev": true,
+      "requires": {
+        "svelte": "^3.0"
+      },
+      "dependencies": {
+        "svelte": {
+          "version": "3.22.3",
+          "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.22.3.tgz",
+          "integrity": "sha512-DumSy5eWPFPlMUGf3+eHyFSkt5yLqyAmMdCuXOE4qc5GtFyLxwTAGKZmgKmW2jmbpTTeFQ/fSQfDBQbl9Eo7yw==",
+          "dev": true
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@babel/preset-env": "~7.8.7",
     "@commitlint/cli": "~8.3.5",
     "@commitlint/config-conventional": "~8.3.4",
+    "@smui/common": "^1.0.0-beta.21",
     "@testing-library/jest-dom": "~5.1.1",
     "@testing-library/svelte": "~1.11.0",
     "@types/jest": "~25.1.3",

--- a/src/components/Choice.svelte
+++ b/src/components/Choice.svelte
@@ -42,36 +42,37 @@
   }
 </script>
 
-<div class="field" class:error={get($touched, name) && get($errors, name)}>
-  <div use:useActions={use} class="{className}" {...exclude($$props, ['use', 'class'])}>
-      {#each options as option}
-        {#if multiple}
-          <input
-            id={option.id}
-            type="checkbox"
-            {name}
-            on:change={onChange}
-            on:blur={onBlur}
-            bind:group={$choice}
-            value={option.id}
-            {...$$restProps} />
-        {:else}
-          <input
-            id={option.id}
-            type="radio"
-            {name}
-            on:change={onChange}
-            on:blur={onBlur}
-            bind:group={$choice}
-            value={option.id}
-            {...$$restProps} />
-        {/if}
-        {#if option.title}
-          <label for={option.id}>{option.title}</label>
-        {/if}
-      {/each}
-      {#if get($touched, name) && get($errors, name)}
-        <div class="message">{get($errors, name)}</div>
-      {/if}
-  </div>
+<div use:useActions={use} 
+     class="field {className}" 
+     class:error={get($touched, name) && get($errors, name)} 
+     {...exclude($$props, ['use', 'class'])}>
+  {#each options as option}
+    {#if multiple}
+      <input
+        id={option.id}
+        type="checkbox"
+        {name}
+        on:change={onChange}
+        on:blur={onBlur}
+        bind:group={$choice}
+        value={option.id}
+        {...$$restProps} />
+    {:else}
+      <input
+        id={option.id}
+        type="radio"
+        {name}
+        on:change={onChange}
+        on:blur={onBlur}
+        bind:group={$choice}
+        value={option.id}
+        {...$$restProps} />
+    {/if}
+    {#if option.title}
+      <label for={option.id}>{option.title}</label>
+    {/if}
+  {/each}
+  {#if get($touched, name) && get($errors, name)}
+    <div class="message">{get($errors, name)}</div>
+  {/if}
 </div>

--- a/src/components/Choice.svelte
+++ b/src/components/Choice.svelte
@@ -9,6 +9,13 @@
   export let options;
   export let multiple = false;
   export let value = '';
+  
+  // `let` usage inspired by Svelte-Material-UI repository
+  import { exclude } from '@smui/common/exclude.js';
+  import { useActions } from '@smui/common/useActions.js';
+  export let use = [];
+  let className = '';
+  export { className as class };
 
   const { touchField, values, errors, touched, validateOnChange } = getContext(
     FORM
@@ -36,33 +43,35 @@
 </script>
 
 <div class="field" class:error={get($touched, name) && get($errors, name)}>
-  {#each options as option}
-    {#if multiple}
-      <input
-        id={option.id}
-        type="checkbox"
-        {name}
-        on:change={onChange}
-        on:blur={onBlur}
-        bind:group={$choice}
-        value={option.id}
-        {...$$restProps} />
-    {:else}
-      <input
-        id={option.id}
-        type="radio"
-        {name}
-        on:change={onChange}
-        on:blur={onBlur}
-        bind:group={$choice}
-        value={option.id}
-        {...$$restProps} />
-    {/if}
-    {#if option.title}
-      <label for={option.id}>{option.title}</label>
-    {/if}
-  {/each}
-  {#if get($touched, name) && get($errors, name)}
-    <div class="message">{get($errors, name)}</div>
-  {/if}
+  <div use:useActions={use} class="{className}" {...exclude($$props, ['use', 'class'])}>
+      {#each options as option}
+        {#if multiple}
+          <input
+            id={option.id}
+            type="checkbox"
+            {name}
+            on:change={onChange}
+            on:blur={onBlur}
+            bind:group={$choice}
+            value={option.id}
+            {...$$restProps} />
+        {:else}
+          <input
+            id={option.id}
+            type="radio"
+            {name}
+            on:change={onChange}
+            on:blur={onBlur}
+            bind:group={$choice}
+            value={option.id}
+            {...$$restProps} />
+        {/if}
+        {#if option.title}
+          <label for={option.id}>{option.title}</label>
+        {/if}
+      {/each}
+      {#if get($touched, name) && get($errors, name)}
+        <div class="message">{get($errors, name)}</div>
+      {/if}
+  </div>
 </div>

--- a/src/components/Form.svelte
+++ b/src/components/Form.svelte
@@ -25,6 +25,13 @@
   let form;
   let fields;
 
+  // `class` usage inspired by the implementation at Svelte-Material-UI
+  import { exclude } from '@smui/common/exclude.js';
+  import { useActions } from '@smui/common/useActions.js';
+  export let use = [];
+  let className = '';
+  export { className as class };
+
   onMount(() => {
     fields = Array.from(form.querySelectorAll('input,textarea,select'))
       .filter(el => !!el.name)
@@ -125,10 +132,13 @@
 </script>
 
 <form
+  use:useActions={use}
   on:submit|preventDefault={handleSubmit}
   on:reset={handleResetClick}
-  class="sveltejs-forms"
-  bind:this={form}>
+  class="sveltejs-forms {className}"
+  bind:this={form}
+  {...exclude($$props, ['use', 'class'])}
+  >
   <slot
     isSubmitting={$isSubmitting}
     {isValid}

--- a/src/components/Input.svelte
+++ b/src/components/Input.svelte
@@ -2,12 +2,16 @@
   import { getContext } from 'svelte';
   import get from 'lodash-es/get';
   import { FORM } from './Form.svelte';
-
+  import { exclude } from '@smui/common/exclude.js';
+  import { useActions } from '@smui/common/useActions.js';
+  
   export let name;
   export let label = '';
   export let type = 'text';
   export let multiline = false;
-
+  export let use = [];
+  let className = '';
+  export {className as class};
   const { touchField, setValue, values, errors, touched } = getContext(FORM);
 
   function onChange(event) {
@@ -23,7 +27,10 @@
   }
 </script>
 
-<div class="field" class:error={get($touched, name) && get($errors, name)}>
+<div use:useActions={use}
+     class="field {className}" 
+     class:error={get($touched, name) && get($errors, name)}
+     {...exclude($$props, ['use', 'class'])}>
   {#if label}
     <label for={name}>{label}</label>
   {/if}


### PR DESCRIPTION
This PR addresses the desire for class keyword usage and attempts to achieve this using `@smui/common/useActions.js`, which serves an identical capability in the Svelte-Material-UI common package. I did not sufficiently test this merge because of time constraints, however this should come close to the desired functionality.