### PR TITLE
Validate choice on store change

### DIFF
--- a/src/components/Choice.svelte
+++ b/src/components/Choice.svelte
@@ -20,7 +20,7 @@
     newValue => set($values, name, newValue)
   );
 
-  $: if ($choice) {
+  function onChange(e) {
     touchField(name, validateOnChange);
   }
 
@@ -42,8 +42,9 @@
         id={option.id}
         type="checkbox"
         {name}
-        on:blur={onBlur}
         bind:group={$choice}
+        on:change={onChange}
+        on:blur={onBlur}
         value={option.id}
         {...$$restProps} />
     {:else}
@@ -51,8 +52,9 @@
         id={option.id}
         type="radio"
         {name}
-        on:blur={onBlur}
         bind:group={$choice}
+        on:change={onChange}
+        on:blur={onBlur}
         value={option.id}
         {...$$restProps} />
     {/if}

--- a/src/components/Choice.svelte
+++ b/src/components/Choice.svelte
@@ -20,7 +20,7 @@
     newValue => set($values, name, newValue)
   );
 
-  function onChange() {
+  $: if ($choice) {
     touchField(name, validateOnChange);
   }
 
@@ -42,7 +42,6 @@
         id={option.id}
         type="checkbox"
         {name}
-        on:change={onChange}
         on:blur={onBlur}
         bind:group={$choice}
         value={option.id}
@@ -52,7 +51,6 @@
         id={option.id}
         type="radio"
         {name}
-        on:change={onChange}
         on:blur={onBlur}
         bind:group={$choice}
         value={option.id}

--- a/src/components/Choice.svelte
+++ b/src/components/Choice.svelte
@@ -20,7 +20,7 @@
     newValue => set($values, name, newValue)
   );
 
-  function onChange(e) {
+  function onChange() {
     touchField(name, validateOnChange);
   }
 


### PR DESCRIPTION
Validating the choice component on store change rather than `on:change` event. The `on:change` event is triggered before the value in the store has changed and therefore validates the wrong data. This closes the issue #170