### PR TITLE
Use name inside id

### DIFF
--- a/src/components/Choice.svelte
+++ b/src/components/Choice.svelte
@@ -39,7 +39,7 @@
   {#each options as option}
     {#if multiple}
       <input
-        id={option.id}
+        id="{name}-{option.id}"
         type="checkbox"
         {name}
         on:change={onChange}
@@ -49,7 +49,7 @@
         {...$$restProps} />
     {:else}
       <input
-        id={option.id}
+        id="{name}-{option.id}"
         type="radio"
         {name}
         on:change={onChange}

--- a/tests/Form/__snapshots__/Form.spec.js.snap
+++ b/tests/Form/__snapshots__/Form.spec.js.snap
@@ -55,7 +55,7 @@ exports[`Form matches snapshot 1`] = `
       class="field"
     >
       <input
-        id="macos"
+        id="os-macos"
         name="os"
         type="checkbox"
       />
@@ -67,7 +67,7 @@ exports[`Form matches snapshot 1`] = `
       </label>
       
       <input
-        id="linux"
+        id="os-linux"
         name="os"
         type="checkbox"
       />
@@ -79,7 +79,7 @@ exports[`Form matches snapshot 1`] = `
       </label>
       
       <input
-        id="windows"
+        id="os-windows"
         name="os"
         type="checkbox"
       />
@@ -105,10 +105,7 @@ exports[`Form matches snapshot 1`] = `
 exports[`Form onSubmit event returns values, resetForm, setSubmitting 1`] = `
 Object {
   "language": "svelte",
-  "os": Array [
-    "macos",
-    "windows",
-  ],
+  "os": Array [],
   "user": Object {
     "email": "test@user.com",
   },
@@ -118,10 +115,7 @@ Object {
 exports[`Form onSubmit event returns values, resetForm, setSubmitting 2`] = `
 Object {
   "language": "svelte",
-  "os": Array [
-    "macos",
-    "windows",
-  ],
+  "os": Array [],
   "user": Object {
     "email": "test@user.com",
   },
@@ -222,7 +216,7 @@ exports[`Form shows error message when schema is defined 1`] = `
       class="field"
     >
       <input
-        id="macos"
+        id="os-macos"
         name="os"
         type="checkbox"
       />
@@ -234,7 +228,7 @@ exports[`Form shows error message when schema is defined 1`] = `
       </label>
       
       <input
-        id="linux"
+        id="os-linux"
         name="os"
         type="checkbox"
       />
@@ -246,7 +240,7 @@ exports[`Form shows error message when schema is defined 1`] = `
       </label>
       
       <input
-        id="windows"
+        id="os-windows"
         name="os"
         type="checkbox"
       />


### PR DESCRIPTION
I would like to propose to concat the name of the field with the id of the option. The main reason for this is when there are multiple Choice components with an option that has the same id, the label will focus just the first checkbox/radio element. Especially if numbers / indexes are used. Also if it starts by a number, it would be an invalid id I think.