### PR TITLE
Added cors allow all option to sirv

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "lint": "eslint --color './**/*.{js,svelte}'",
     "test": "jest --verbose",
     "autobuild": "rollup -c -w",
-    "start:dev": "sirv public --single --dev",
+    "start:dev": "sirv public -c --single --dev",
     "dev": "run-p start:dev autobuild",
     "build": "rollup -c",
     "prepublishOnly": "npm run build",


### PR DESCRIPTION
While developing micro-frontend (later mf) application I found that sirv currently blocks all requests from other domains. In case with mf each frontend while developed is hosted on different port which triggers cors.

This simple tweak fixes that.